### PR TITLE
ci: introduce uv to accelerate pip install

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -26,6 +26,11 @@ jobs:
       image: ${{ inputs.image }}
       env:
         HOME: /root
+        UV_INDEX_URL: "https://mirrors.huaweicloud.com/repository/pypi/simple"
+        UV_EXTRA_INDEX_URL: "https://mirrors.huaweicloud.com/ascend/repos/pypi"
+        UV_INDEX_STRATEGY: "unsafe-best-match"
+        UV_NO_CACHE: 1
+        UV_SYSTEM_PYTHON: 1
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
@@ -43,7 +48,8 @@ jobs:
       - name: Compile torch
         working-directory: /root/build/pytorch/pytorch
         run: |
-          pip3 install -r requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple
+          pip3 install uv
+          uv pip install -r requirements.txt
           export _GLIBCXX_USE_CXX11_ABI=1
           export USE_CUDA=0
           export USE_XNNPACK=0
@@ -51,11 +57,11 @@ jobs:
       - name: Compile and install torch_npu
         working-directory: /root/build/npu/pytorch
         run: |
-          pip3 install -r requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple
+          uv pip install -r requirements.txt
           bash ci/build.sh --python=3.8
-          pip3 install dist/torch_npu*.whl
+          uv pip install dist/torch_npu*.whl
       - name: Do the test
         working-directory: /root/build
         run: |
-          pip3 install -r npu/pytorch/test/requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple --no-deps
+          uv pip install -r npu/pytorch/test/requirements.txt --no-deps
           python npu/pytorch/ci/access_control_test.py


### PR DESCRIPTION
Replace pip3 install with uv pip install in _build-and-test.yml to speed up CI dependency resolution. All pip3 install calls use the Huawei mirror index (-i), which uv supports natively.