### PR TITLE
ci: use internal pip cache service instead of public mirror

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -40,10 +40,14 @@ jobs:
       - name: Prepare the codes
         run: |
           \cp -rf /root/codes/ /root/build
+      - name: Config pip mirror
+        run: |
+          pip3 config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+          pip3 config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
       - name: Compile torch
         working-directory: /root/build/pytorch/pytorch
         run: |
-          pip3 install -r requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple
+          pip3 install -r requirements.txt
           export _GLIBCXX_USE_CXX11_ABI=1
           export USE_CUDA=0
           export USE_XNNPACK=0
@@ -51,11 +55,11 @@ jobs:
       - name: Compile and install torch_npu
         working-directory: /root/build/npu/pytorch
         run: |
-          pip3 install -r requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple
+          pip3 install -r requirements.txt
           bash ci/build.sh --python=3.8
           pip3 install dist/torch_npu*.whl
       - name: Do the test
         working-directory: /root/build
         run: |
-          pip3 install -r npu/pytorch/test/requirements.txt -i https://mirrors.huaweicloud.com/repository/pypi/simple --no-deps
+          pip3 install -r npu/pytorch/test/requirements.txt --no-deps
           python npu/pytorch/ci/access_control_test.py


### PR DESCRIPTION
## Summary

Replace the hardcoded `-i https://mirrors.huaweicloud.com/repository/pypi/simple` flags in `_build-and-test.yml` with a single `Config pip mirror` step that configures the internal K8s cache service globally via `pip3 config set`.

**Before**: each `pip3 install` command had an explicit `-i` flag pointing to the public Huawei Cloud mirror.

**After**: a single setup step sets `global.index-url` to the internal cache service, and all subsequent `pip3 install` commands inherit it automatically.

## Benefits

- Reduces redundancy (one place to update the mirror URL)
- Internal cache service is faster and more reliable within the cluster
- Consistent with the pattern used in other Ascend CI workflows

## Test plan

- [ ] Verify `Config pip mirror` step runs successfully in the container
- [ ] Verify `pip3 install -r requirements.txt` resolves packages from the internal cache