### PR TITLE
fix(profiler): make trace_view.json compatible with Perfetto / Chrome Trace Format

### DIFF
--- a/torch_npu/profiler/analysis/prof_common_func/_trace_event_manager.py
+++ b/torch_npu/profiler/analysis/prof_common_func/_trace_event_manager.py
@@ -1,5 +1,6 @@
+import itertools
+
 from ._constant import Constant
-from ._constant import convert_ns2us_str
 from ._constant import convert_ns2us_float
 
 __all__ = []
@@ -15,9 +16,12 @@ class TraceEventManager:
     PID_OFFSET = 10
     INDEX_OFFSET = 5
 
+    # Sequential counter for flow event IDs (avoids values > 2^53)
+    _flow_id_counter = itertools.count(1)
+
     @classmethod
     def create_x_event(cls, event: any, cat: str) -> dict:
-        return {"ph": "X", "name": event.name, "pid": event.pid, "tid": event.tid, "ts": convert_ns2us_str(event.ts),
+        return {"ph": "X", "name": event.name, "pid": event.pid, "tid": event.tid, "ts": convert_ns2us_float(event.ts),
                 "dur": convert_ns2us_float(event.dur), "cat": cat, "args": event.args}
 
     @classmethod
@@ -39,17 +43,22 @@ class TraceEventManager:
         return event_list
 
     @classmethod
+    def _next_flow_id(cls) -> int:
+        """Return a monotonically increasing integer safe for JavaScript (under 2^53)."""
+        return next(cls._flow_id_counter)
+
+    @classmethod
     def create_torch_to_npu_flow(cls, start_event: any, end_event: any) -> list:
-        flow_id = end_event.ts
+        flow_id = cls._next_flow_id()
         return [{"ph": "s", "bp": "e", "name": "torch_to_npu", "id": flow_id, "pid": start_event.pid,
-                 "tid": start_event.tid, "ts": convert_ns2us_str(start_event.ts), "cat": "async_npu"},
+                 "tid": start_event.tid, "ts": convert_ns2us_float(start_event.ts), "cat": "async_npu"},
                 {"ph": "f", "bp": "e", "name": "torch_to_npu", "id": flow_id, "pid": end_event.pid,
-                 "tid": end_event.tid, "ts": convert_ns2us_str(end_event.ts), "cat": "async_npu"}]
+                 "tid": end_event.tid, "ts": convert_ns2us_float(end_event.ts), "cat": "async_npu"}]
 
     @classmethod
     def create_task_queue_flow(cls, ph: str, event: any) -> dict:
         return {"ph": ph, "bp": "e", "name": "enqueue_to_dequeue", "id": event.corr_id, "pid": event.pid,
-                "tid": event.tid, "ts": convert_ns2us_str(event.ts), "cat": "async_task_queue"}
+                "tid": event.tid, "ts": convert_ns2us_float(event.ts), "cat": "async_task_queue"}
 
     @classmethod
     def create_fwd_flow(cls, event: any) -> list:
@@ -60,9 +69,9 @@ class TraceEventManager:
                     continue
                 flow_id = fwd_id
                 fwd_list.extend([{"ph": "s", "bp": "e", "name": "fwdbwd", "id": flow_id, "pid": node['start']['pid'],
-                    "tid": node['start']['tid'], "ts": convert_ns2us_str(node['start']['ts']), "cat": "fwdbwd"},
+                    "tid": node['start']['tid'], "ts": convert_ns2us_float(node['start']['ts']), "cat": "fwdbwd"},
                     {"ph": "f", "bp": "e", "name": "fwdbwd", "id": flow_id, "pid": node['end']['pid'],
-                    "tid": node['end']['tid'], "ts": convert_ns2us_str(node['end']['ts']), "cat": "fwdbwd"}])
+                    "tid": node['end']['tid'], "ts": convert_ns2us_float(node['end']['ts']), "cat": "fwdbwd"}])
         return fwd_list
 
     @classmethod

--- a/torch_npu/profiler/analysis/prof_view/_trace_view_parser.py
+++ b/torch_npu/profiler/analysis/prof_view/_trace_view_parser.py
@@ -68,6 +68,25 @@ class TraceViewParser(BaseParser):
         self.logger.info("TraceViewParser finish.")
         return Constant.SUCCESS, None
 
+    @staticmethod
+    def _normalize_timestamps(trace_data: list) -> None:
+        """Convert absolute timestamps to relative (subtract min ts in-place)
+        and ensure ts/dur are numeric, compatible with Chrome Trace Format / Perfetto."""
+        if not trace_data:
+            return
+        # Find the minimum numeric ts among all events (metadata events like "M" have no ts)
+        min_ts = float("inf")
+        for event in trace_data:
+            ts = event.get("ts")
+            if ts is not None and isinstance(ts, (int, float)):
+                min_ts = min(min_ts, ts)
+        if min_ts == float("inf") or min_ts == 0:
+            return
+        for event in trace_data:
+            ts = event.get("ts")
+            if ts is not None and isinstance(ts, (int, float)):
+                event["ts"] = round(ts - min_ts, 3)
+
     def generate_view(self) -> None:
         if not ProfilerPathManager.get_cann_path(self._profiler_path):
             self._trace_data = FwkFileParser(self._profiler_path).get_fwk_trace_data(
@@ -78,6 +97,8 @@ class TraceViewParser(BaseParser):
                 self._prune_trace_by_level(msprof_timeline_data))
             if self._torch_op_node:
                 self._trace_data.extend(self._get_flow_event(msprof_timeline_data))
+        # Normalize to relative timestamps for Perfetto / Chrome Trace Format compatibility
+        self._normalize_timestamps(self._trace_data)
         if os.path.exists(self._temp_trace_file_path):
             FileManager.append_trace_json_by_path(self._temp_trace_file_path, self._trace_data, self._trace_file_path)
         else:


### PR DESCRIPTION
## Problem

Issue #133: torch_npu profiler trace_view.json is incompatible with Perfetto.

**Root causes:**
1. ts field was a string, Chrome Trace Format requires a number
2. ts used absolute epoch timestamps causing float64 precision loss
3. Flow event id exceeded JavaScript MAX_SAFE_INTEGER (2^53)

## Changes

### _trace_event_manager.py
- Changed ts from string to numeric float (convert_ns2us_float)
- Flow event id now uses sequential counter (under 2^53)

### _trace_view_parser.py
- Added _normalize_timestamps() to make timestamps relative

## Related
Closes https://github.com/Ascend/pytorch/issues/133