### PR TITLE
Register the NPU DTensor RNG tracker and dispatch key

### DIFF
--- a/torch_npu/distributed/__init__.py
+++ b/torch_npu/distributed/__init__.py
@@ -33,3 +33,10 @@ from .distributed_c10d import (
     _reduce_scatter_tensor_uneven as reduce_scatter_tensor_uneven,
     _all_gather_into_tensor_uneven as all_gather_into_tensor_uneven,
 )
+
+
+# Register the NPU DTensor RNG tracker and the run_dtensor_rng_op dispatch
+# key (no-op on torch versions without the upstream registration APIs).
+from torch_npu.distributed.tensor._random import register_npu_dtensor_rng
+
+register_npu_dtensor_rng()

--- a/torch_npu/distributed/tensor/_random.py
+++ b/torch_npu/distributed/tensor/_random.py
@@ -1,0 +1,69 @@
+"""DTensor RNG support for the NPU device.
+
+Upstream PyTorch (the DTensor RNG tracker registry and the DTensor random
+higher-order operator) lets third-party backends register:
+
+* a device-specific RNG tracker via
+  ``torch.distributed.tensor._random.register_rng_tracker``, and
+* the ``run_dtensor_rng_op`` dispatch key via
+  ``torch._prims.rng_prims.register_run_dtensor_rng_dispatch``
+
+instead of hardcoding the CUDA philox assumption in core. This module wires
+the NPU device into those registries.
+
+NPU's generator state is philox-layout compatible (16 bytes: uint64 seed +
+uint64 offset, offset in multiples of 4), so the offset-based machinery of
+``OffsetBasedRNGTracker`` applies as-is, with one documented semantic
+difference versus CUDA:
+
+* On CUDA, the offset indexes a window into a single value stream:
+  generating ``n`` values at offset ``O`` reproduces stream positions
+  ``[O, O + n)`` of the base stream.
+* On NPU, each offset value selects an independent philox stream, and an RNG
+  kernel launch advances the offset by a fixed stride (12) regardless of how
+  many values were consumed.
+
+DTensor random ops on NPU are therefore deterministic and reproducible, and
+distinct shards draw from distinct (uncorrelated) philox streams, but shard
+values are NOT bitwise-equal to the corresponding slices of an unsharded
+``torch.rand`` call. Rank 0's shard (start offset increment 0) does match the
+prefix of the unsharded stream at the same generator state.
+"""
+
+from torch.distributed.tensor._random import OffsetBasedRNGTracker
+
+__all__ = ["NpuRNGStateTracker", "register_npu_dtensor_rng"]
+
+
+class NpuRNGStateTracker(OffsetBasedRNGTracker):
+    """Offset-based DTensor RNG tracker for the NPU device.
+
+    The NPU generator state layout (16-byte seed/offset) and the
+    ``get_rng_state``/``set_rng_state`` APIs match the philox contract of
+    ``OffsetBasedRNGTracker``, so the inherited offset bookkeeping applies
+    unchanged. See the module docstring for the NPU stream semantics.
+    """
+
+
+def register_npu_dtensor_rng() -> bool:
+    """Register the NPU DTensor RNG tracker and HOP dispatch key.
+
+    Registers ``NpuRNGStateTracker`` for the ``npu`` device type and the
+    device-generic ``run_dtensor_rng_op`` implementation for the
+    ``PrivateUse1`` dispatch key, so DTensor random ops on NPU run through
+    the traceable higher-order operator path.
+
+    Returns ``True`` when registered, ``False`` on torch versions without
+    the upstream registration APIs (in which case this is a no-op and keeps
+    torch_npu importable across torch versions).
+    """
+    try:
+        from torch._C import DispatchKey
+        from torch._prims.rng_prims import register_run_dtensor_rng_dispatch
+        from torch.distributed.tensor._random import register_rng_tracker
+    except ImportError:
+        return False
+
+    register_rng_tracker("npu", NpuRNGStateTracker)
+    register_run_dtensor_rng_dispatch(DispatchKey.PrivateUse1)
+    return True


### PR DESCRIPTION
## Summary

Upstream PyTorch is adding registration points so third-party backends can participate in DTensor random ops without core code changes (draft PRs pytorch/pytorch#195245 / #195246):

- `torch.distributed.tensor._random.register_rng_tracker(device_type, cls)`
- `torch._prims.rng_prims.register_run_dtensor_rng_dispatch(dispatch_key)`

This PR registers the NPU device into both, following the same pattern as `register_npu_graphsafe_rng()` in `torch_npu/utils/_dynamo.py`:

- `NpuRNGStateTracker` subclasses `OffsetBasedRNGTracker`; the NPU generator state layout (16-byte seed/offset, offset in multiples of 4) matches the philox contract, so the inherited offset bookkeeping applies unchanged.
- the device-generic `run_dtensor_rng_op` implementation is registered for the `PrivateUse1` dispatch key, so DTensor random ops on NPU run through the traceable higher-order operator path.

The registration is guarded by `ImportError` and is a no-op on torch versions without the upstream APIs, so torch_npu stays importable against any torch.

## Documented semantic difference versus CUDA

On CUDA, the RNG offset indexes a window into a single value stream: generating `n` values at offset `O` reproduces stream positions `[O, O+n)` of the base stream. On NPU, each offset value selects an **independent philox stream**, and an RNG kernel launch advances the offset by a fixed stride (12) regardless of the number of values consumed (measured empirically on 910B/CANN 9.1.0).

Consequently DTensor random ops on NPU are deterministic and reproducible, and distinct shards draw from uncorrelated streams, but shard values are **not** bitwise-equal to the corresponding slices of an unsharded `torch.rand` call. Rank 0's shard (start offset increment 0) does match the prefix of the unsharded stream. This is stated in the module docstring so users are not surprised.

## Verification (Ascend 910B, CANN 9.1.0, torch 2.14 + the two upstream draft PRs)

2-rank hccl mesh, `DTensor.uniform_` on a Shard(0) 2-way mesh:

- the tracker created is `NpuRNGStateTracker`; the op runs through `run_dtensor_rng_op` (HOP path);
- rank 0's shard == unsharded `torch.rand` prefix; rank 1's shard == the independent stream at offset 8 (as documented); rank shards differ;
- offsets advance by the global numel per op (0 -> 16 -> 32) and stay valid multiples of 4;
- results are identical across reruns;
- `test/distributed/tensor/test_random_ops.py` (full file) on the 4-card NPU container: `Ran 55, OK (skipped=42)` — no regressions.

Dependency note: this PR is the reference consumer of the two upstream draft PRs; until they land, the registration is inert on stock torch (ImportError guard), so merging order is free.
